### PR TITLE
Add support for minor Ruby versions to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ branches:
 language: ruby
 
 rvm:
-  - 2.5.1
+  - '2.3'
+  - '2.4'
+  - '2.5'
 
 before_install: gem install bundler -v 1.16.3
 

--- a/fidor_api.gemspec
+++ b/fidor_api.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.3'
-
   spec.add_dependency 'activemodel', '~> 5.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'faraday_middleware', '~> 0.12'

--- a/fidor_api.gemspec
+++ b/fidor_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '~> 2.3'
 
   spec.add_dependency 'activemodel', '~> 5.0'
   spec.add_dependency 'faraday', '~> 0.15'

--- a/lib/fidor_api/model/base.rb
+++ b/lib/fidor_api/model/base.rb
@@ -2,6 +2,9 @@ module FidorApi
   module Model
     class Base
       class << self
+        # This makes define_method public to support Ruby lower than 2.5
+        public :define_method # rubocop:disable Style/AccessModifierDeclarations
+
         def inherited(klass)
           klass.include ActiveModel::Model
           klass.include Helpers::ActionViewSupport
@@ -22,7 +25,7 @@ module FidorApi
       attr_accessor :confirmable_action_id
 
       def as_json
-        attributes.compact
+        attributes
       end
 
       def parse_errors(body) # rubocop:disable Metrics/AbcSize

--- a/lib/fidor_api/model/base.rb
+++ b/lib/fidor_api/model/base.rb
@@ -25,7 +25,7 @@ module FidorApi
       attr_accessor :confirmable_action_id
 
       def as_json
-        attributes
+        attributes.delete_if { |_, v| v.nil? }
       end
 
       def parse_errors(body) # rubocop:disable Metrics/AbcSize

--- a/lib/fidor_api/model/base.rb
+++ b/lib/fidor_api/model/base.rb
@@ -25,7 +25,7 @@ module FidorApi
       attr_accessor :confirmable_action_id
 
       def as_json
-        attributes.delete_if { |_, v| v.nil? }
+        attributes.reject { |_, v| v.nil? }
       end
 
       def parse_errors(body) # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
- Added support for minor Ruby versions `2.3`, `2.4` and `2.5`
- Makes `define_method` public in `FidorApi::Model::Base` for backwards compatibility with Ruby lower than `2.5`.  This was changed in https://github.com/ruby/ruby/commit/ac1193d38f12e6ce5106f5413bcc57b6f585a2a1 for  Ruby `2.5`