### PR TITLE
Requre ruby version ~> 2.5

### DIFF
--- a/fidor_api.gemspec
+++ b/fidor_api.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 2.5'
+
   spec.add_dependency 'activemodel', '~> 5.0'
   spec.add_dependency 'faraday', '~> 0.15'
   spec.add_dependency 'faraday_middleware', '~> 0.12'


### PR DESCRIPTION
The currently does not work with `ruby-2.3.7` and `ruby-2.4.4`.  Until https://github.com/fidor/fidor_api/pull/7 is merged, we can add the required version.