### PR TITLE
Allow instance-specific headers when making standard DSL calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ rvm:
   - '2.4'
   - '2.5'
 
-before_install: gem install bundler -v 1.17.2
-
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/fidor_api.gemspec
+++ b/fidor_api.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.12'
   spec.add_dependency 'model_attribute', '~> 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'byebug', '~> 10.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/fidor_api/client/dsl.rb
+++ b/lib/fidor_api/client/dsl.rb
@@ -26,11 +26,13 @@ module FidorApi
       private
 
       def fetch(type, klass, endpoint, options)
+        headers = options.delete(:headers) || {}
+
         case type
         when :single
-          klass.new(connection.get(endpoint, query: options).body)
+          klass.new(connection.get(endpoint, query: options, headers: headers).body)
         when :collection
-          Collection.new(klass: klass, raw: connection.get(endpoint, query: options).body)
+          Collection.new(klass: klass, raw: connection.get(endpoint, query: options, headers: headers).body)
         else
           raise ArgumentError
         end

--- a/spec/features/dsl/core_data_spec.rb
+++ b/spec/features/dsl/core_data_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe 'DSL - Core Data' do
       expect(account.id).to eq 42
     end
   end
+
+  it 'supports query params' do
+    stub_fetch_request(endpoint: %r{/users/current},
+      request_params: {query: {fields: 'id,email'}},
+      response_body: {id: 42, email: 'example@email.org'})
+
+    user = client.user fields: 'id,email'
+
+    expect(user.id).to eq 42
+    expect(user.email).to eq 'example@email.org'
+  end
+
+  it 'supports per-instance headers' do
+    stub_fetch_request(endpoint: %r{/accounts},
+      request_params: {headers: {'Any-Header' => 'Basic stuff'}}, response_body: [id: 42])
+
+    account = client.accounts(headers: {'Any-Header' => 'Basic stuff'}).first
+
+    expect(account.id).to eq 42
+  end
 end

--- a/spec/features/dsl/core_data_spec.rb
+++ b/spec/features/dsl/core_data_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe 'DSL - Core Data' do
 
   it 'supports query params' do
     stub_fetch_request(endpoint: %r{/users/current},
-      request_params: {query: {fields: 'id,email'}},
-      response_body: {id: 42, email: 'example@email.org'})
+      request_params: { query: { fields: 'id,email' } }, response_body:  { id: 42, email: 'example@email.org' })
 
     user = client.user fields: 'id,email'
 
@@ -60,9 +59,9 @@ RSpec.describe 'DSL - Core Data' do
 
   it 'supports per-instance headers' do
     stub_fetch_request(endpoint: %r{/accounts},
-      request_params: {headers: {'Any-Header' => 'Basic stuff'}}, response_body: [id: 42])
+      request_params: { headers: { 'Any-Header' => 'Basic stuff' } }, response_body: [id: 42])
 
-    account = client.accounts(headers: {'Any-Header' => 'Basic stuff'}).first
+    account = client.accounts(headers: { 'Any-Header' => 'Basic stuff' }).first
 
     expect(account.id).to eq 42
   end

--- a/spec/support/client_helper.rb
+++ b/spec/support/client_helper.rb
@@ -8,7 +8,7 @@ module ClientHelper
     end
   end
 
-  def stub_fetch_request(endpoint:, response_body:, response_headers: {})
+  def stub_fetch_request(endpoint:, response_body:, response_headers: {}, request_params: nil)
     if response_body.is_a? Array
       response_body = {
         data:       response_body,
@@ -23,8 +23,14 @@ module ClientHelper
 
     response_body = response_body.to_json if response_body.is_a? Hash
 
-    stub_request(:get, endpoint)
-      .to_return(status: 200, headers: json_response_header.merge(response_headers), body: response_body)
+    stubbed_request =
+      if request_params
+        stub_request(:get, endpoint).with(request_params)
+      else
+        stub_request(:get, endpoint)
+      end
+
+    stubbed_request.to_return(status: 200, headers: json_response_header.merge(response_headers), body: response_body)
   end
 
   def stub_create_request(endpoint:, response_body:, response_headers: {}, status: 201)


### PR DESCRIPTION
Hello, guys, thank you for providing this nice gem!

While playing with it, I've noticed that `Client::DSL#request` method supports passing `headers` hash but the standard DSLs interpret provided options as `GET` queries only (which generally makes sense), for example:
```ruby
# GET /transactions?filter%5Btransaction_types%5D=foo%2bar
filtered_transactions = client.transactions(filter: {transaction_types: 'foo,bar'})
```

How about adding the possibility to pass per-instance request headers along when making DSL calls? E.g.
```ruby
# GET /transactions?filter%5Btransaction_types%5D=baz
client.transactions(
  filter: {transaction_types: 'baz'}, 
  headers: {Accept => 'application/vnd.fidor.de; version=5'}
)
```
so that this specific instance would query a version of your API that's different from the default one. Maybe this approach could add more flexibility when you, say, publish new API versions?

Cheers!

P.S. I've also added a test case for sparse fields queries which seem to be supported.