### PR TITLE
Support non-root endpoints

### DIFF
--- a/lib/fidor_api/client/dsl/accounts.rb
+++ b/lib/fidor_api/client/dsl/accounts.rb
@@ -3,7 +3,7 @@ module FidorApi
     module DSL
       module Accounts
         def account_transactions(id, options = {})
-          fetch(:collection, Model::Transaction, "/accounts/#{id}/transactions", options)
+          fetch(:collection, Model::Transaction, "accounts/#{id}/transactions", options)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/cards.rb
+++ b/lib/fidor_api/client/dsl/cards.rb
@@ -3,11 +3,11 @@ module FidorApi
     module DSL
       module Cards
         def cards(options = {})
-          fetch(:collection, Model::Card, '/cards', options)
+          fetch(:collection, Model::Card, 'cards', options)
         end
 
         def card(id, options = {})
-          fetch(:single, Model::Card, "/cards/#{id}", options)
+          fetch(:single, Model::Card, "cards/#{id}", options)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/confirmable_actions.rb
+++ b/lib/fidor_api/client/dsl/confirmable_actions.rb
@@ -3,15 +3,15 @@ module FidorApi
     module DSL
       module ConfirmableActions
         def confirmable_action(id, options = {})
-          fetch(:single, Model::ConfirmableAction, "/confirmable/actions/#{id}", options)
+          fetch(:single, Model::ConfirmableAction, "confirmable/actions/#{id}", options)
         end
 
         def refresh_confirmable_action(id, options = {})
-          update(Model::ConfirmableAction, "/confirmable/actions/#{id}/refresh", id, options)
+          update(Model::ConfirmableAction, "confirmable/actions/#{id}/refresh", id, options)
         end
 
         def update_confirmable_action(id, attributes = {})
-          update(Model::ConfirmableAction, "/confirmable/actions/#{id}", id, attributes)
+          update(Model::ConfirmableAction, "confirmable/actions/#{id}", id, attributes)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/core_data.rb
+++ b/lib/fidor_api/client/dsl/core_data.rb
@@ -3,15 +3,15 @@ module FidorApi
     module DSL
       module CoreData
         def user(options = {})
-          fetch(:single, Model::User, '/users/current', options)
+          fetch(:single, Model::User, 'users/current', options)
         end
 
         def customers(options = {})
-          fetch(:collection, Model::Customer, '/customers', options)
+          fetch(:collection, Model::Customer, 'customers', options)
         end
 
         def accounts(options = {})
-          fetch(:collection, Model::Account, '/accounts', options)
+          fetch(:collection, Model::Account, 'accounts', options)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/messages.rb
+++ b/lib/fidor_api/client/dsl/messages.rb
@@ -3,15 +3,15 @@ module FidorApi
     module DSL
       module Messages
         def messages(options = {})
-          fetch(:collection, Model::Message, '/messages', options)
+          fetch(:collection, Model::Message, 'messages', options)
         end
 
         def message(id, options = {})
-          fetch(:single, Model::Message, "/messages/#{id}", options)
+          fetch(:single, Model::Message, "messages/#{id}", options)
         end
 
         def message_attachment(id)
-          response = connection.get("/messages/#{id}/attachment")
+          response = connection.get("messages/#{id}/attachment")
 
           Model::Message::Attachment.new(
             type:     response.headers['content-type'],
@@ -21,7 +21,7 @@ module FidorApi
         end
 
         def message_content(id)
-          response = connection.get("/messages/#{id}/content")
+          response = connection.get("messages/#{id}/content")
 
           Model::Message::Content.new(raw: response.body)
         end

--- a/lib/fidor_api/client/dsl/preauths.rb
+++ b/lib/fidor_api/client/dsl/preauths.rb
@@ -3,11 +3,11 @@ module FidorApi
     module DSL
       module Preauths
         def preauths(options = {})
-          fetch(:collection, Model::Preauth, '/preauths', options)
+          fetch(:collection, Model::Preauth, 'preauths', options)
         end
 
         def preauth(id, options = {})
-          fetch(:single, Model::Preauth, "/preauths/#{id}", options)
+          fetch(:single, Model::Preauth, "preauths/#{id}", options)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/standing_orders.rb
+++ b/lib/fidor_api/client/dsl/standing_orders.rb
@@ -3,7 +3,7 @@ module FidorApi
     module DSL
       module StandingOrders
         def standing_order(id, options = {})
-          fetch(:single, FidorApi::Model::StandingOrder, "/standing_orders/#{id}", options)
+          fetch(:single, FidorApi::Model::StandingOrder, "standing_orders/#{id}", options)
         end
 
         def new_standing_order(attributes = {})
@@ -11,7 +11,7 @@ module FidorApi
         end
 
         def create_standing_order(attributes = {})
-          create(FidorApi::Model::StandingOrder, '/standing_orders', attributes)
+          create(FidorApi::Model::StandingOrder, 'standing_orders', attributes)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/transactions.rb
+++ b/lib/fidor_api/client/dsl/transactions.rb
@@ -3,11 +3,11 @@ module FidorApi
     module DSL
       module Transactions
         def transactions(options = {})
-          fetch(:collection, Model::Transaction, '/transactions', options)
+          fetch(:collection, Model::Transaction, 'transactions', options)
         end
 
         def transaction(id, options = {})
-          fetch(:single, Model::Transaction, "/transactions/#{id}", options)
+          fetch(:single, Model::Transaction, "transactions/#{id}", options)
         end
       end
     end

--- a/lib/fidor_api/client/dsl/transfers/classic.rb
+++ b/lib/fidor_api/client/dsl/transfers/classic.rb
@@ -5,12 +5,12 @@ module FidorApi
         module Classic
           def internal_transfers(options = {})
             check_transfer_support! :classic
-            fetch(:collection, FidorApi::Model::Transfer::Classic::Internal, '/internal_transfers', options)
+            fetch(:collection, FidorApi::Model::Transfer::Classic::Internal, 'internal_transfers', options)
           end
 
           def internal_transfer(id, options = {})
             check_transfer_support! :classic
-            fetch(:single, FidorApi::Model::Transfer::Classic::Internal, "/internal_transfers/#{id}", options)
+            fetch(:single, FidorApi::Model::Transfer::Classic::Internal, "internal_transfers/#{id}", options)
           end
 
           def new_internal_transfer(attributes = {})
@@ -20,17 +20,17 @@ module FidorApi
 
           def create_internal_transfer(attributes = {})
             check_transfer_support! :classic
-            create(FidorApi::Model::Transfer::Classic::Internal, '/internal_transfers', attributes)
+            create(FidorApi::Model::Transfer::Classic::Internal, 'internal_transfers', attributes)
           end
 
           def sepa_transfers(options = {})
             check_transfer_support! :classic
-            fetch(:collection, FidorApi::Model::Transfer::Classic::SEPA, '/sepa_credit_transfers', options)
+            fetch(:collection, FidorApi::Model::Transfer::Classic::SEPA, 'sepa_credit_transfers', options)
           end
 
           def sepa_transfer(id, options = {})
             check_transfer_support! :classic
-            fetch(:single, FidorApi::Model::Transfer::Classic::SEPA, "/sepa_credit_transfers/#{id}", options)
+            fetch(:single, FidorApi::Model::Transfer::Classic::SEPA, "sepa_credit_transfers/#{id}", options)
           end
 
           def new_sepa_transfer(attributes = {})
@@ -40,7 +40,7 @@ module FidorApi
 
           def create_sepa_transfer(attributes = {})
             check_transfer_support! :classic
-            create(FidorApi::Model::Transfer::Classic::SEPA, '/sepa_credit_transfers', attributes)
+            create(FidorApi::Model::Transfer::Classic::SEPA, 'sepa_credit_transfers', attributes)
           end
         end
       end

--- a/lib/fidor_api/client/dsl/transfers/generic.rb
+++ b/lib/fidor_api/client/dsl/transfers/generic.rb
@@ -5,12 +5,12 @@ module FidorApi
         module Generic
           def transfers(options = {})
             check_transfer_support! :generic
-            fetch(:collection, FidorApi::Model::Transfer::Generic, '/transfers', options)
+            fetch(:collection, FidorApi::Model::Transfer::Generic, 'transfers', options)
           end
 
           def transfer(id, options = {})
             check_transfer_support! :generic
-            fetch(:single, FidorApi::Model::Transfer::Generic, "/transfers/#{id}", options)
+            fetch(:single, FidorApi::Model::Transfer::Generic, "transfers/#{id}", options)
           end
 
           def new_transfer(attributes = {})
@@ -20,12 +20,12 @@ module FidorApi
 
           def create_transfer(attributes = {})
             check_transfer_support! :generic
-            create(FidorApi::Model::Transfer::Generic, '/transfers', attributes)
+            create(FidorApi::Model::Transfer::Generic, 'transfers', attributes)
           end
 
           def update_transfer(id, attributes = {})
             check_transfer_support! :generic
-            update(FidorApi::Model::Transfer::Generic, "/transfers/#{id}", id, attributes)
+            update(FidorApi::Model::Transfer::Generic, "transfers/#{id}", id, attributes)
           end
         end
       end


### PR DESCRIPTION
Hello fidor :)

Sometimes (depending on certain proxy setups), the endpoint of the fidor API could be in a subdirectory. With the current hardcoded root paths, any additional path information of the environment is removed.

With this change, it is now possible to define an environment where the endpoint is prefixed, for example hosted like this:

`http://vpn.proxy:27840/fidor`

and then for example the accounts request will be made to `http://vpn.proxy:27840/fidor/accounts` instead of `http://vpn.proxy:27840/accounts`.