### PR TITLE
Return the entire start confirmation response

### DIFF
--- a/lib/fidor_api/client.rb
+++ b/lib/fidor_api/client.rb
@@ -8,6 +8,9 @@ module FidorApi
     include Authentication
     include DSL
 
+    deprecator = ActiveSupport::Deprecation.new('2.2', 'fidor_api')
+    ActiveSupport::Deprecation.deprecate_methods(self, confirm_transfer: 'Migrate to create_transfer_confirmation', deprecator: deprecator)
+
     attr_accessor :config
 
     def initialize

--- a/lib/fidor_api/client.rb
+++ b/lib/fidor_api/client.rb
@@ -8,9 +8,6 @@ module FidorApi
     include Authentication
     include DSL
 
-    deprecator = ActiveSupport::Deprecation.new('2.2', 'fidor_api')
-    ActiveSupport::Deprecation.deprecate_methods(self, confirm_transfer: 'Migrate to create_transfer_confirmation', deprecator: deprecator)
-
     attr_accessor :config
 
     def initialize

--- a/lib/fidor_api/client/dsl/transfers/generic.rb
+++ b/lib/fidor_api/client/dsl/transfers/generic.rb
@@ -29,6 +29,10 @@ module FidorApi
           end
 
           def confirm_transfer(id, options = {})
+            create_transfer_confirmation(id, options).body.dig('links', 'redirect')
+          end
+
+          def create_transfer_confirmation(id, options = {})
             check_transfer_support! :generic
             request(:put, "/transfers/#{id}/confirm", {}, options[:headers])
           end

--- a/lib/fidor_api/client/dsl/transfers/generic.rb
+++ b/lib/fidor_api/client/dsl/transfers/generic.rb
@@ -29,10 +29,6 @@ module FidorApi
           end
 
           def confirm_transfer(id, options = {})
-            create_transfer_confirmation(id, options).body.dig('links', 'redirect')
-          end
-
-          def create_transfer_confirmation(id, options = {})
             check_transfer_support! :generic
             request(:put, "/transfers/#{id}/confirm", {}, options[:headers])
           end

--- a/lib/fidor_api/client/dsl/transfers/generic.rb
+++ b/lib/fidor_api/client/dsl/transfers/generic.rb
@@ -30,7 +30,7 @@ module FidorApi
 
           def confirm_transfer(id, options = {})
             check_transfer_support! :generic
-            request(:put, "/transfers/#{id}/confirm", {}, options.delete(:headers)).headers['Location']
+            request(:put, "/transfers/#{id}/confirm", {}, options[:headers])
           end
         end
       end

--- a/spec/features/dsl/transfers/generic_spec.rb
+++ b/spec/features/dsl/transfers/generic_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'DSL - Transfers - Generic' do
         endpoint:         %r{/transfers/92bf870d-d914-4757-8691-7f8092a77e0e/confirm},
         request_headers:  request_headers,
         response_body:    {
-          id: 'eb5e8e0d-4611-4124-a1c5-f0b1afad250b',
+          id:    'eb5e8e0d-4611-4124-a1c5-f0b1afad250b',
           links: { redirect: redirect_link }
         },
         response_headers: { 'Location' => location },

--- a/spec/features/dsl/transfers/generic_spec.rb
+++ b/spec/features/dsl/transfers/generic_spec.rb
@@ -136,16 +136,22 @@ RSpec.describe 'DSL - Transfers - Generic' do
       stub_update_request(
         endpoint:         %r{/transfers/92bf870d-d914-4757-8691-7f8092a77e0e/confirm},
         request_headers:  request_headers,
+        response_body:    {
+          id: 'eb5e8e0d-4611-4124-a1c5-f0b1afad250b',
+          links: { redirect: redirect_link }
+        },
         response_headers: { 'Location' => location },
         status:           303
       )
     end
 
-    let(:location) { 'https://auth.example.com/confirmable/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
+    let(:location) { 'https://api.example.com/confirm/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
+    let(:redirect_link) { 'https://auth.example.com/confirmable/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
 
     it 'returns the value from the location header' do
       return_value = client.confirm_transfer('92bf870d-d914-4757-8691-7f8092a77e0e', headers: request_headers)
-      expect(return_value).to eq location
+      expect(return_value.headers['Location']).to eq location
+      expect(return_value.body['links']['redirect']).to eq redirect_link
     end
   end
 end

--- a/spec/features/dsl/transfers/generic_spec.rb
+++ b/spec/features/dsl/transfers/generic_spec.rb
@@ -150,6 +150,29 @@ RSpec.describe 'DSL - Transfers - Generic' do
 
     it 'returns the value from the location header' do
       return_value = client.confirm_transfer('92bf870d-d914-4757-8691-7f8092a77e0e', headers: request_headers)
+      expect(return_value).to eq redirect_link
+    end
+  end
+
+  describe '#create_transfer_confirmation' do
+    before do
+      stub_update_request(
+        endpoint:         %r{/transfers/92bf870d-d914-4757-8691-7f8092a77e0e/confirm},
+        request_headers:  request_headers,
+        response_body:    {
+          id:    'eb5e8e0d-4611-4124-a1c5-f0b1afad250b',
+          links: { redirect: redirect_link }
+        },
+        response_headers: { 'Location' => location },
+        status:           303
+      )
+    end
+
+    let(:location) { 'https://api.example.com/confirm/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
+    let(:redirect_link) { 'https://auth.example.com/confirmable/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
+
+    it 'returns the value from the location header' do
+      return_value = client.create_transfer_confirmation('92bf870d-d914-4757-8691-7f8092a77e0e', headers: request_headers)
       expect(return_value.headers['Location']).to eq location
       expect(return_value.body['links']['redirect']).to eq redirect_link
     end

--- a/spec/features/dsl/transfers/generic_spec.rb
+++ b/spec/features/dsl/transfers/generic_spec.rb
@@ -150,29 +150,6 @@ RSpec.describe 'DSL - Transfers - Generic' do
 
     it 'returns the value from the location header' do
       return_value = client.confirm_transfer('92bf870d-d914-4757-8691-7f8092a77e0e', headers: request_headers)
-      expect(return_value).to eq redirect_link
-    end
-  end
-
-  describe '#create_transfer_confirmation' do
-    before do
-      stub_update_request(
-        endpoint:         %r{/transfers/92bf870d-d914-4757-8691-7f8092a77e0e/confirm},
-        request_headers:  request_headers,
-        response_body:    {
-          id:    'eb5e8e0d-4611-4124-a1c5-f0b1afad250b',
-          links: { redirect: redirect_link }
-        },
-        response_headers: { 'Location' => location },
-        status:           303
-      )
-    end
-
-    let(:location) { 'https://api.example.com/confirm/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
-    let(:redirect_link) { 'https://auth.example.com/confirmable/eb5e8e0d-4611-4124-a1c5-f0b1afad250b' }
-
-    it 'returns the value from the location header' do
-      return_value = client.create_transfer_confirmation('92bf870d-d914-4757-8691-7f8092a77e0e', headers: request_headers)
       expect(return_value.headers['Location']).to eq location
       expect(return_value.body['links']['redirect']).to eq redirect_link
     end


### PR DESCRIPTION
With the latest API response, the redirect link is now part of the payload and the location header points to the API endpoint. Clients thus need the entire response to be able to either go the API route or use the payload for the redirect link.