### PR TITLE
Add created_at for display on frontend

### DIFF
--- a/lib/fidor_api/model/scheduled_transfer.rb
+++ b/lib/fidor_api/model/scheduled_transfer.rb
@@ -14,6 +14,7 @@ module FidorApi
       attribute :beneficiary,    :json
       attribute :state,          :string
       attribute :scheduled_date, :string
+      attribute :created_at,     :string
 
       attribute_decimal_methods :amount
 


### PR DESCRIPTION
Scheduled transfer allows immediate execution of the transfer if the scheduled_date is not provided.

Having created_at makes sense as it is the date when the transfer was created