### PR TITLE
Do not crash when logger is set to false

### DIFF
--- a/lib/fidor_api/client/connection.rb
+++ b/lib/fidor_api/client/connection.rb
@@ -37,7 +37,7 @@ module FidorApi
 
         response
       rescue Faraday::ClientError => e
-        client.config.logger.error e.inspect
+        client.config.logger.error e.inspect if client.config.logger # rubocop:disable Style/SafeNavigation
         raise
       end
 


### PR DESCRIPTION
When using custom logging middleware, the user will set `config.logger` to false in order to suppress the built in logging. However this will crash during the logging of 4xx responses, as this does not respect the logger setting and instead will call `#error` on false.