### PR TITLE
remove message attr. from error hash

### DIFF
--- a/lib/fidor_api/model/base.rb
+++ b/lib/fidor_api/model/base.rb
@@ -37,8 +37,7 @@ module FidorApi
 
           if key
             # https://github.com/rails/rails/issues/28903
-            hash.delete('message')
-            errors.add(field, key.to_sym, hash.symbolize_keys)
+            errors.add(field, key.to_sym, hash.symbolize_keys.except(:message))
           else
             errors.add(field, hash.delete('message'), hash.symbolize_keys)
           end

--- a/lib/fidor_api/model/base.rb
+++ b/lib/fidor_api/model/base.rb
@@ -36,6 +36,8 @@ module FidorApi
           next unless respond_to?(field) || field == :base
 
           if key
+            # https://github.com/rails/rails/issues/28903
+            hash.delete('message')
             errors.add(field, key.to_sym, hash.symbolize_keys)
           else
             errors.add(field, hash.delete('message'), hash.symbolize_keys)

--- a/spec/lib/fidor_api/model/base_spec.rb
+++ b/spec/lib/fidor_api/model/base_spec.rb
@@ -63,7 +63,7 @@ module FidorApi
             'code'   => 422,
             'errors' => [
               { 'field' => 'base', 'message' => 'Something is wrong in general' },
-              { 'field' => 'amount', 'key' => 'invalid' },
+              { 'field' => 'amount', 'key' => 'greater_than', 'count' => 0 },
               { 'field' => 'amount', 'key' => 'invalid', 'message' => 'is not valid' }
             ]
           }
@@ -72,7 +72,7 @@ module FidorApi
         it 'assigns the errors and supports i18n keys' do
           instance.parse_errors(errors)
           expect(instance.errors[:base]).to eq ['Something is wrong in general']
-          expect(instance.errors[:amount]).to eq ['is invalid', 'is not valid']
+          expect(instance.errors[:amount]).to eq ['must be greater than 0', 'is invalid']
         end
       end
 


### PR DESCRIPTION
* remove `message` attr. from error hash to enable i18n lookup
  * https://github.com/rails/rails/issues/28903